### PR TITLE
Ignore dependency patches

### DIFF
--- a/src/Patches.php
+++ b/src/Patches.php
@@ -180,8 +180,20 @@ class Patches implements PluginInterface, EventSubscriberInterface {
       }
     }
 
-    // Merge installed patches from dependencies that did not receive an update.
+    // Merge installed patches from dependencies that did not receive an update and are not ignored.
     foreach ($this->installedPatches as $patches) {
+      foreach ($patches as $package => $patches_package) {
+        $ignore = array();
+        foreach ($patches_package as $index => $patch) {
+          if (isset($patches_ignore[$package]) && array_search($patch, $patches_ignore[$package]) !== FALSE) {
+            $ignore[] = $index . ' - ' . $patch;
+            unset($patches[$package][$index]);
+          }
+        }
+        if (!empty($ignore)) {
+          $this->io->write('<info>Ignore ' . $package . ' patches: ' . implode(', ', $ignore) . '</info>');
+        }
+      }
       $this->patches = array_merge_recursive($this->patches, $patches);
     }
 


### PR DESCRIPTION
Ignoring patches defined in the composer.json of a dependency doesn't work.

The following change works with a setup like this (note the missing level in comparison with the current readme):

```
    "patches-ignore": {
      "drupal/core": {
        "This patch has known conflicts with our own Views patch": "https://www.drupal.org/files/issues/2369119-120.patch"
      }
    }
```